### PR TITLE
Update version to 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here is how to build it:
 
 Check the options available in your app:
 
-    java -jar target/bootique-flyway-demo-1.0-SNAPSHOT.jar
+    java -jar target/bootique-flyway-demo-2.0.jar
     
     OPTIONS
       -b, --baseline
@@ -123,7 +123,7 @@ public class V3__Update_table implements JdbcMigration {
 
 Run migration:
 ```bash
-java -jar target/bootique-flyway-demo-1.0-SNAPSHOT.jar --config=config.yml --migrate
+java -jar target/bootique-flyway-demo-2.0.jar --config=config.yml --migrate
 ```    
 Result:
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>io.bootique.flyway.demo</groupId>
     <artifactId>bootique-flyway-demo</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0</version>
 
     <name>bootique-flyway-demo</name>
 
@@ -38,7 +38,7 @@
             <dependency>
                 <groupId>io.bootique.bom</groupId>
                 <artifactId>bootique-bom</artifactId>
-                <version>${project.version}</version>
+                <version>2.0-SNAPSHOT</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/Application.java
+++ b/src/main/java/Application.java
@@ -1,6 +1,7 @@
+import io.bootique.BaseModule;
 import io.bootique.Bootique;
 
-public class Application {
+public class Application extends BaseModule {
 
     public static void main(String[] args) {
         Bootique.app(args)

--- a/src/main/java/db/migration/V3__Update_table.java
+++ b/src/main/java/db/migration/V3__Update_table.java
@@ -2,22 +2,31 @@ package db.migration;
 
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
 /**
  * Example of a Java-based migration.
  */
 public class V3__Update_table extends BaseJavaMigration {
+    private static Logger LOGGER = LoggerFactory.getLogger(V3__Update_table.class);
 
     @Override
     public void migrate(Context context) throws Exception {
-        try (Connection connection = context.getConnection()){
-            try(PreparedStatement statement = connection
-                    .prepareStatement("INSERT INTO TEST (name) VALUES ('test3')")) {
-                statement.execute();
-            }
+        Connection connection = context.getConnection();
+        PreparedStatement statement =
+                connection.prepareStatement("INSERT INTO TEST (name) VALUES ('test3')");
+
+        try {
+            statement.execute();
+        } catch (SQLException e) {
+            LOGGER.error("Migration failed", e);
+        } finally {
+            statement.close();
         }
     }
 }


### PR DESCRIPTION
Changed project version to 2.0 and Application class extends BaseModule. bootique-bom updated to 2.0-SNAPSHOT.
migrate(Context context) method fixed. There was an error 'java.sql.SQLException: PooledConnection has already been closed'. The method is taken from the README.  
Jar file name changed in README.